### PR TITLE
Bug Fix: Popup doesn't close on outside click

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -170,6 +170,20 @@ function handleCellClick(cell, name, source, year, e) {
       popupScore.blur();
     }
   });
+  document.addEventListener('click', (e) => {
+  const isInsidePopup = popup.contains(e.target);
+  const isSameCell = currentCell && currentCell.contains(e.target);
+  const isProblemCell = e.target.closest('.problem-cell');
+
+  if (!isInsidePopup && !isSameCell && popup.classList.contains('show')) {
+    popup.classList.remove('show');
+    popup.classList.add('hidden');
+    if (currentCell) {
+      handlePopupClose(currentCell);
+      currentCell = null;
+    }
+  }
+});
 }
 
 document.querySelectorAll('.problem-cell').forEach(cell => {


### PR DESCRIPTION
Fixes #5

### 🐛 Bug Fix: Popup doesn't close on outside click
This PR fixes a UI issue where the popup remains open even after clicking outside of it.

### ✅ What Changed
- Added a global click listener that checks if the click is outside the popup and active cell
- Closes the popup and resets `currentCell` accordingly

### 🔍 Related
- Closes #5 