### PR TITLE
Improved colour contrast and added/removed problems

### DIFF
--- a/data/problems/ceoi/2021.yaml
+++ b/data/problems/ceoi/2021.yaml
@@ -13,13 +13,17 @@
   links:
   - https://oj.uz/problem/view/CEOI21_newspapers
   - https://qoj.ac/problem/2276
-- name: Tortoise
+- name: Stones
   number: 4
+  links:
+  - https://evaluator.hsin.hr/tasks/SC2021CEOI21stones/
+- name: Tortoise
+  number: 5
   links:
   - https://oj.uz/problem/view/CEOI21_tortoise
   - https://qoj.ac/problem/2278
 - name: Wells
-  number: 5
+  number: 6
   links:
   - https://oj.uz/problem/view/CEOI21_wells
   - https://qoj.ac/problem/2279

--- a/data/problems/noifinal/2018.yaml
+++ b/data/problems/noifinal/2018.yaml
@@ -28,7 +28,3 @@
   - https://oj.uz/problem/view/NOI18_safety
   - https://qoj.ac/problem/13299
   - https://acmicpc.net/problem/19693
-- name: Sorting
-  number: 6
-  links:
-  - https://acmicpc.net/problem/19694

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -227,7 +227,7 @@ h2 {
 
 .day-cell {
     background-color: #f5f5f5;
-    color: #1184ff;
+    color: #ffffffb1;
     padding: 8px 4px;
     width: 150px;
     min-width: 150px;
@@ -250,17 +250,6 @@ h2 {
     color: #005eff;
     font-weight: 500;
     font-size: 16.5px
-}
-
-.day-cell {
-    background-color: #f5f5f5;
-    color: #1184ff;
-    padding: 8px 4px;
-    width: 150px;
-    min-width: 150px;
-    max-width: 150px;
-    white-space: nowrap;
-    text-align: center;
 }
 
 #status-popup {

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -214,7 +214,7 @@ h2 {
 
 .year-cell {
     font-weight: bold;
-    color: #007bff;
+    color: #ffffffb1;
     background-color: #eee;
     white-space: nowrap;
     text-align: center;

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -214,7 +214,7 @@ h2 {
 
 .year-cell {
     font-weight: bold;
-    color: #ffffffb1;
+    color: #007bff;
     background-color: #eee;
     white-space: nowrap;
     text-align: center;
@@ -227,7 +227,7 @@ h2 {
 
 .day-cell {
     background-color: #f5f5f5;
-    color: #ffffffb1;
+    color: #1184ff;
     padding: 8px 4px;
     width: 150px;
     min-width: 150px;
@@ -750,6 +750,7 @@ input:not(:checked)+.slider {
 .dark-mode .year-cell,
 .dark-mode .day-cell {
     background-color: #29282873;
+    color: #ffffffb1
 }
 
 .dark-mode table,

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -249,7 +249,7 @@ h2 {
     text-decoration: none;
     color: #005eff;
     font-weight: 500;
-    font-size: 16.5px
+    font-size: 16px
 }
 
 #status-popup {
@@ -756,7 +756,7 @@ input:not(:checked)+.slider {
 .dark-mode table,
 .dark-mode td,
 .dark-mode th {
-    border: 1.5px solid #373737;
+    border: 1px solid #373737;
     /* softer gray border */
 }
 

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -247,8 +247,9 @@ h2 {
 
 .problem-cell a {
     text-decoration: none;
-    color: #007bff;
+    color: #005eff;
     font-weight: 500;
+    font-size: 16.5px
 }
 
 .day-cell {
@@ -759,13 +760,13 @@ input:not(:checked)+.slider {
 
 .dark-mode .year-cell,
 .dark-mode .day-cell {
-    background-color: #202938;
+    background-color: #29282873;
 }
 
 .dark-mode table,
 .dark-mode td,
 .dark-mode th {
-    border: 1px solid #2a2a2a;
+    border: 1.5px solid #373737;
     /* softer gray border */
 }
 
@@ -774,15 +775,15 @@ input:not(:checked)+.slider {
 }
 
 .dark-mode .green {
-    background-color: #64cd69;
+    background-color: #3dbb43e4;
 }
 
 .dark-mode .yellow {
-    background-color: #e6b800;
+    background-color: #ffcc01cb;
 }
 
 .dark-mode .red {
-    background-color: #f44336;
+    background-color: #650700;
 }
 
 .dark-mode .problem-cell.skeleton {
@@ -1032,7 +1033,7 @@ body.dark-mode .settings-label {
     font-size: 14px;
     /* Increase font size for legibility */
     font-weight: bold;
-    color: #333;
+    color: #c10000;
     text-decoration: none;
     background-color: transparent;
     border: none;


### PR DESCRIPTION
The green, yellow and red colours looked very bright in dark mode and were in general standing out from the main website theme. Also the problem names were hard to read (especially in red). Now there is no eye strain and I tried my best to make the text readable while ensuring the colours look good.

Added CEOI 2021 day 2 p1 Stones. It was not available on oj.uz or qoj.ac. I've added link of evaluator.
Removed Singapore NOI Final 2018 Scoring. It doesn't exist in the actual olympiad lol.